### PR TITLE
implemented radar refresh

### DIFF
--- a/electron/public/current-forecast.html
+++ b/electron/public/current-forecast.html
@@ -71,6 +71,7 @@
       </div>
     </div>
     <div class="bottom-strip">
+      <div class="error-message">Connection Error</div>
       <!-- This strip will have forecast weather 'cards'-->
       <div class="hourly-menu-enclosure">
         <a class="hourly-view-link" href="hourly.html"> Hourly </a>

--- a/electron/public/radar.html
+++ b/electron/public/radar.html
@@ -21,9 +21,12 @@
     <i class="fas fa-road selected"></i>
     <i class="fas fa-satellite"></i>
   </div>
-  <div class="close-config-enclosure">
-    <div class="close-settings-icon">
-      <i class="fas fa-times close-button"></i>
+  <div class="radar-options-enclosure">
+    <div class="refresh-settings-icon radar-option">
+      <i class="fas fa-sync-alt" alt="refresh"></i>
+    </div>
+    <div class="close-settings-icon radar-option">
+      <i class="fas fa-times close-button" alt="close"></i>
     </div>
   </div>
   <div class="map-enclosure">

--- a/electron/scripts/hourly.js
+++ b/electron/scripts/hourly.js
@@ -55,9 +55,15 @@ async function updateHourlyForecast(maxHrs = 48) {
     units
   } = getFetchConfigData(window.localStorage));
 
-  ({
-    data
-  } = await getForecastFromAPI(lat, lon, key, units));
+  try {
+    ({
+      data
+    } = await getForecastFromAPI(lat, lon, key, units));
+    $(".error-message").css("visibility", "hidden");
+  } catch (exception) {
+    // Show a user-friendly error
+    $(".error-message").css("visibility", "visible");
+  }
 
   const hourlyObjects = data.hourly.slice(0, maxHrs);
 

--- a/electron/scripts/radar.js
+++ b/electron/scripts/radar.js
@@ -12,7 +12,7 @@ const SATELLITE_VIEW = "mapbox/satellite-v9";
 const DEFAULT_STREET_VIEW = "mapbox/streets-v11";
 
 $(() => {
-  $(".close-config-enclosure").click((e) => {
+  $(".close-settings-icon").click((e) => {
     window.location.href = "current-forecast.html";
   });
 
@@ -37,6 +37,11 @@ $(() => {
       window.location = "radar.html";
     }
   });
+
+  $(".fa-sync-alt").click((e) => {
+    window.location = "radar.html";
+  });
+
   loadConfigureMap();
 });
 

--- a/electron/scripts/weather-functions.js
+++ b/electron/scripts/weather-functions.js
@@ -42,6 +42,7 @@ export function getWindSpeed(speed, units) {
  */
 export async function getForecastFromAPI(lat, lon, key, units) {
   const url = `https://api.openweathermap.org/data/2.5/onecall?lat=${lat}&lon=${lon}&appid=${key}&units=${units}`;
+  console.log("Forecast URL:", url);
   return await axios.get(url);
 }
 
@@ -150,7 +151,6 @@ function updateHumidity(data) {
 }
 
 /**
- * 
  * @param {{}} data 
  */
 function updateAtmosphericPressure(data) {
@@ -162,7 +162,7 @@ function updateAtmosphericPressure(data) {
 }
 
 /**
- * Returns two hourly forecasts; the now + 6, and the other now + 12
+ * Returns two hourly forecasts; the now + 6 hours, and the other now + 12 hours
  * @param {} data 
  */
 function updateNextTwelveHourForecast(data) {

--- a/electron/styles/radar.css
+++ b/electron/styles/radar.css
@@ -12,6 +12,10 @@
   height: 25px;
 }
 
+.radar-options-enclosure {
+  font-size: 20px;
+}
+
 .map-enclosure {
   display: block;
 }
@@ -20,14 +24,22 @@
   cursor: pointer;
 }
 
-.close-button {
-  float: right;
-}
-
 .selected {
   color: red;
 }
 
 .map-view-options-enclosure {
   margin-bottom: 2px;
+}
+
+.radar-option {
+  cursor: pointer;
+}
+
+.close-settings-icon {
+  float: right;
+}
+
+.refresh-settings-icon {
+  display: inline-block;
 }

--- a/electron/styles/weather.css
+++ b/electron/styles/weather.css
@@ -389,3 +389,7 @@ li {
     text-shadow: 0 0 20px #fff, 0 0 30px red, 0 0 40px red, 0 0 50px red, 0 0 60px #ff4da6, 0 0 70px #ff4da6, 0 0 80px black;
   }
 }
+
+.error-message {
+  visibility: hidden;
+}


### PR DESCRIPTION
Resolves #28 

Added a refresh button and refresh functionality to radar screen.
Added an error message that will display on forecast screen if there's a connectivity issue and we can't pull data from the API.